### PR TITLE
gomu: move httpserve.Context to vroomy/common interface for plugin shared imports

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"io"
+	"net/http"
+)
+
+// Plugins represents the plugins library interface. This allows for plugins and libraries
+// to not be affected by vroomy/plugins version changes.
+type Plugins interface {
+	Backend(key string, val interface{}) error
+}
+
+// Context is the http context plugins need to support handlers
+type Context interface {
+	// Write will write a byteslice
+	Write(bs []byte) (n int, err error)
+
+	// WriteString will write a string
+	WriteString(str string) (n int, err error)
+
+	// Param will return the associated parameter value with the provided key
+	Param(key string) (value string)
+	// Get will retrieve a value for a provided key from the Context's internal storage
+	Get(key string) (value string)
+
+	// Put will set a value for a provided key into the Context's internal storage
+	Put(key, value string)
+
+	// BindJSON is a helper function which binds the request body to a provided value to be parsed as JSON
+	BindJSON(value interface{}) (err error)
+
+	// AddHook will add a hook function to be ran after the context has completed
+	AddHook(func(statusCode int, storage map[string]string))
+
+	// GetRequest will return http.Request
+	GetRequest() (req *http.Request)
+
+	// GetWriter will return response writer.
+	GetWriter() (writer http.ResponseWriter)
+}
+
+// Handler is the HTTP handler type
+type Handler func(ctx *Context) Response
+
+// Response is the http response handlers return
+type Response interface {
+	StatusCode() (code int)
+	ContentType() (contentType string)
+	WriteTo(w io.Writer) (n int64, err error)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -40,15 +40,30 @@ type Context interface {
 	// GetWriter will return response writer.
 	GetWriter() (writer http.ResponseWriter)
 
-	// NewJSONResponse will return a json response object
-	NewJSONResponse(code int, value interface{}) (resp interface{})
+	// NewAdoptResponse will return an adopt response object
+	NewAdoptResponse() (resp Response)
 
-	// NewTextResponse will return a json response object
-	NewTextResponse(code int, body []byte) (resp interface{})
+	// NewNoContentResponse will return a no content response object
+	NewNoContentResponse() (resp Response)
+
+	// NewRedirectResponse will return a redirect response object
+	NewRedirectResponse(code int, route string) (resp Response)
+
+	// NewJSONResponse will return a json response object
+	NewJSONResponse(code int, value interface{}) (resp Response)
+
+	// NewJSONPResponse will return a json response object with callback
+	NewJSONPResponse(callback string, value interface{}) (resp Response)
+
+	// NewTextResponse will return a text response object
+	NewTextResponse(code int, body []byte) (resp Response)
+
+	// NewXMLResponse will return an xml response object
+	NewXMLResponse(code int, body []byte) (resp Response)
 }
 
 // Handler is the HTTP handler type
-type Handler func(ctx *Context) Response
+type Handler func(ctx Context) Response
 
 // Response is the http response handlers return
 type Response interface {

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,6 +21,7 @@ type Context interface {
 
 	// Param will return the associated parameter value with the provided key
 	Param(key string) (value string)
+
 	// Get will retrieve a value for a provided key from the Context's internal storage
 	Get(key string) (value string)
 
@@ -38,6 +39,12 @@ type Context interface {
 
 	// GetWriter will return response writer.
 	GetWriter() (writer http.ResponseWriter)
+
+	// NewJSONResponse will return a json response object
+	NewJSONResponse(code int, value interface{}) (resp interface{})
+
+	// NewTextResponse will return a json response object
+	NewTextResponse(code int, body []byte) (resp interface{})
 }
 
 // Handler is the HTTP handler type

--- a/plugins.go
+++ b/plugins.go
@@ -1,7 +1,0 @@
-package common
-
-// Plugins represents the plugins library interface. This allows for plugins and libraries
-// to not be affected by vroomy/plugins version changes.
-type Plugins interface {
-	Backend(key string, val interface{}) error
-}


### PR DESCRIPTION
This allows plugins to import vroomy/common instead of http serve!